### PR TITLE
Fix table of contents anchors in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,17 +11,17 @@ Spring Boot, Kotlin, and event-driven architecture.
 
 ## 📋 Table of Contents
 
-- [Overview](#overview)
-- [Architecture](#architecture)
-- [Technologies](#technologies)
-- [Prerequisites](#prerequisites)
-- [Quick Start](#quick-start)
-- [API Documentation](#api-documentation)
-- [Project Structure](#project-structure)
-- [Development](#development)
-- [Testing](#testing)
-- [Contributing](#contributing)
-- [License](#license)
+- [Overview](#-overview)
+- [Architecture](#-architecture)
+- [Technologies](#-technologies)
+- [Prerequisites](#-prerequisites)
+- [Quick Start](#-quick-start)
+- [API Documentation](#-api-documentation)
+- [Project Structure](#-project-structure)
+- [Development](#-development)
+- [Testing](#-testing)
+- [Contributing](#-contributing)
+- [License](#-license)
 
 ## 🔍 Overview
 


### PR DESCRIPTION
Updated the table of contents in the README to ensure proper navigation:
- Added hyphens to match rendered markdown anchor links.
- Fixed incorrect links for smoother navigation.