### PR TITLE
Bump Kotlin version to 2.2.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CQRS Microservices - Order Management System
 
-[![Kotlin](https://img.shields.io/badge/kotlin-2.2.0-blue.svg?logo=kotlin)](http://kotlinlang.org)
+[![Kotlin](https://img.shields.io/badge/kotlin-2.2.10-blue.svg?logo=kotlin)](http://kotlinlang.org)
 [![Spring Boot](https://img.shields.io/badge/spring--boot-4.0.0--SNAPSHOT-brightgreen.svg?logo=springboot)](https://spring.io/projects/spring-boot)
 [![Java](https://img.shields.io/badge/java-21-blue.svg?logo=openjdk)](https://openjdk.org/)
 [![Gradle](https://img.shields.io/badge/gradle-9.0.0-blue.svg?logo=gradle)](https://gradle.org/)
@@ -41,7 +41,7 @@ communication, and different data storage optimized for each operation type.
 - **Message Queue**: RabbitMQ for reliable event processing
 - **API Documentation**: OpenAPI/Swagger integration
 - **Comprehensive Testing**: Unit and integration tests with Testcontainers
-- **Modern Tech Stack**: Spring Boot 4.0, Kotlin 2.2, Java 21
+- **Modern Tech Stack**: Spring Boot 4.0, Kotlin 2.2.10, Java 21
 
 ## 🏗️ Architecture
 
@@ -195,7 +195,7 @@ Query Service (Inbox Pattern):
 
 ## 🛠️ Technologies
 
-- **Language**: Kotlin 2.2.0
+- **Language**: Kotlin 2.2.10
 - **Framework**: Spring Boot 4.0.0-SNAPSHOT
 - **JVM**: Java 21
 - **Build Tool**: Gradle

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
-    kotlin("jvm") version "2.2.0" apply false
-    kotlin("plugin.spring") version "2.2.0" apply false
-    kotlin("plugin.jpa") version "2.2.0" apply false
+    kotlin("jvm") version "2.2.10" apply false
+    kotlin("plugin.spring") version "2.2.10" apply false
+    kotlin("plugin.jpa") version "2.2.10" apply false
     id("org.springframework.boot") version "4.0.0-SNAPSHOT" apply false
     id("io.spring.dependency-management") version "1.1.7" apply false
     id("org.hibernate.orm") version "7.1.0.Final" apply false
@@ -20,8 +20,6 @@ allprojects {
 }
 
 subprojects {
-    extra["snippetsDir"] = file("build/generated-snippets")
-
     apply(plugin = "io.spring.dependency-management")
 
     configure<io.spring.gradle.dependencymanagement.dsl.DependencyManagementExtension> {


### PR DESCRIPTION
### Summary

This pull request updates the Kotlin version to 2.2.10. The following changes have been made:
- Updated Kotlin plugins (jvm, spring, jpa) to version 2.2.10.
- Removed the unused `snippetsDir` configuration from subprojects.

### Checklist

- [ ] Does this address a known issue?
- [ ] Do the changes work as expected without introducing regressions?
- [ ] Are the dependencies updated as appropriate?
- [ ] Are relevant tests included or updated?
- [ ] Is the code documented appropriately?